### PR TITLE
Support disabling automatic updates by tags

### DIFF
--- a/htpc-playbook.yml
+++ b/htpc-playbook.yml
@@ -57,7 +57,7 @@
         AutomaticLoginEnable=True
         AutomaticLogin=kodi
 
-  # Just comment this if you don't want automatic updates
+  # If you don't want automatic updates run the ansible with `--skip-tags auto-updates`
   - name: Setup automatic updates
     cron:
       name: "Updates"
@@ -65,6 +65,8 @@
       minute: 0
       hour: 4
       job: "flatpak update -y; rpm-ostree upgrade; reboot"
+    tags:
+      - auto-updates
 
   - name: Rebbot machine
     reboot:


### PR DESCRIPTION
I would recommend to avoid commenting code in the playbook it is messing versioning system. This solution will skip that part using tags.

**Needs to be tested before merge.**